### PR TITLE
Unpin conda build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 7c285fc40ad0c113e436a1271c4e38b5017b5c7782c306e90be9d6b2ffa90212
 
 build:
-  number: 0
+  number: 1
   skip: true  # [win or (unix and not py27)]
   features:
     - vc9     # [win and py27]


### PR DESCRIPTION
Resolves an issue where `conda-build` is packaging symlinks to `activate`, `conda`, and `deactivate` created by `conda`/`conda-env`. This problem doesn't seem to occur with the latest `conda-build` on Linux. So, it would seem logical that unpinning `conda-build` might solve the issue.
