### PR TITLE
Bump build number to trigger new CI builds

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 858db2faf348f89fdf1062bd3e79256772e897e7f17df73e0624edf004f2f9ac
 
 build:
-  number: 0
+  number: 1
   skip: true  # [(win and py36) or (unix and not py27)]
   features:
     - vc9  # [win and py27]


### PR DESCRIPTION
In the hopes of getting a clean linux build of v1.8.1 (see #6).